### PR TITLE
feat(tools): foundry support

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,50 @@
+[default]
+auto_detect_solc = true
+block_base_fee_per_gas = 0
+block_coinbase = '0x0000000000000000000000000000000000000000'
+block_difficulty = 0
+block_number = 0
+block_timestamp = 0
+cache = true
+cache_path = 'cache'
+evm_version = 'london'
+extra_output = []
+extra_output_files = []
+ffi = false
+force = false
+fuzz_max_global_rejects = 65536
+fuzz_max_local_rejects = 1024
+fuzz_runs = 256
+gas_limit = 80000000
+gas_price = 0
+gas_reports = ['*']
+ignored_error_codes = [1878]
+initial_balance = '0xffffffffffffffffffffffff'
+libraries = []
+libs = ['lib']
+names = false
+no_storage_caching = false
+offline = false
+optimizer = true
+optimizer_runs = 200
+out = 'out'
+remappings = [
+    '@openzeppelin/=lib/openzeppelin-contracts/',
+    'ds-auth/=lib/ds-auth/src/',
+    'ds-math/=lib/ds-math/src/',
+    'ds-note/=lib/ds-note/src/',
+    'ds-test/=lib/ds-test/src/',
+    'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/',
+]
+sender = '0x00a329c0648769a73afac7f9381e08fb43dbea72'
+sizes = false
+src = 'src'
+test = 'test'
+tx_origin = '0x00a329c0648769a73afac7f9381e08fb43dbea72'
+verbosity = 0
+via_ir = false
+
+[rpc_storage_caching]
+chains = 'all'
+endpoints = 'remote'
+


### PR DESCRIPTION
Dapptools unfortunately is in maintenance mode as of two days ago. 

I am actually using your Mock Provider in a test suite, and thought you might find it useful potentially

```shell
forge test  -f $ETH_RPC_URL -vvv  -- debug $TEST_$1

1=test_SetResponse_For_Query
2=test_SetResponse_For_Selector
3=test_SetResponse_ToFail_ForQuery
4=test_DefaultCalldata_Returns_SetResponse
```

```shell
Running 4 tests for MockProviderTest.json:MockProviderTest
[PASS] test_DefaultCalldata_Returns_SetResponse(bytes) (runs: 256, μ: 209327, ~: 196998)
[PASS] test_SetResponse_For_Query() (gas: 83724)
Logs:
  0x5678
  0x5678

[PASS] test_SetResponse_For_Selector(bytes) (runs: 256, μ: 86446, ~: 86394)
[PASS] test_SetResponse_ToFail_ForQuery() (gas: 39710)
```