### PR TITLE
🚊 Add methods to enable/disable arbitrary query logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Methods to consume all gas for a given query or function selector: `givenSelectorConsumeGas(bytes4 selector_)` and `givenQueryConsumeGas(bytes memory query_)`
+- Add methods to enable/disable global logging: `disableLogging` / `enableLogging`; mock provider is initialized to log arbitrary requests.
 
 ### Changed
 - Update config file to new Foundry version [#12](https://github.com/cleanunicorn/mockprovider/issues/12)

--- a/src/MockProvider.sol
+++ b/src/MockProvider.sol
@@ -45,6 +45,10 @@ contract MockProvider is Test {
     /// @dev keccak256(query) => bool
     mapping(bytes32 => bool) internal _givenQuerySet;
 
+    /// @notice Whether arbitrary queries should be logged
+    /// @dev starts as enabled
+    bool public loggingEnabled = true;
+
     /// @notice Whether the query should be logged
     /// @dev keccak256(query) => bool
     mapping(bytes32 => bool) internal _givenQueryLog;
@@ -62,6 +66,18 @@ contract MockProvider is Test {
             revert MockProvider__getCallData_indexOutOfBounds(index_);
         }
         return _callData[index_];
+    }
+
+    /// @notice Disables logging of arbitrary queries
+    /// @dev Any query that isn't explicitly set, will not be logged
+    function disableLogging() public {
+        loggingEnabled = false;
+    }
+
+    /// @notice Enables logging of arbitrary queries
+    /// @dev Any query that isn't explicitly set, will be logged
+    function enableLogging() public {
+        loggingEnabled = true;
     }
 
     /// @notice Defines the default return in case no query matches
@@ -240,7 +256,9 @@ contract MockProvider is Test {
         } 
 
         // Log the call
-        _logCall();
+        if (loggingEnabled) {
+            _logCall();
+        }
 
         // Default to sending the default response
         return _defaultReturnData.data;


### PR DESCRIPTION
### Description

Adds methods to enable or disable global logging.

- `mockProvider.disableLogging()`
- `mockProvider.enableLogging()`

Mock provider is initialised to log arbitrary requests, by default.

Should not break default functionality and should help when calling arbitrary `view` methods. The problem is that calling an arbitrary method creates an error when trying to log it because the code is executed with [`STATICCALL`](https://eips.ethereum.org/EIPS/eip-214) and the execution fails immediately when state is updated.

### Issues

- Closes #8 

### Todo

- [x] Link issues
- [ ] Link projects
- [x] Update tests
- [x] Update code
- [x] Comment code
- [x] Test locally
- [x] Update changelog
